### PR TITLE
Bump to latest CastXML

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
       - image: thewtex/centos-build:latest
     working_directory: /usr/src/CastXMLSuperbuild
+    resource_class: xlarge
     steps:
       - checkout
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(extra_flags "-static-libstdc++")
 endif()
 # 2017-04-05
-set(CastXML_GIT_TAG fab9c47d251a7973eed066d3eec3b83bcf9d0582 CACHE STRING "CastXML Git revision.")
+set(CastXML_GIT_TAG 927c73942c659d924a43ac08c34c1b04fc807d11 CACHE STRING "CastXML Git revision.")
 ExternalProject_Add(castxml
   GIT_REPOSITORY https://github.com/CastXML/CastXML.git
   GIT_TAG ${CastXML_GIT_TAG}

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 CastXML Superbuild
 ==================
 
-.. image:: https://circleci.com/gh/CastXML/CastXMLSuperbuild.svg?style=svg
+.. image:: https://circleci.com/gh/CastXML/CastXMLSuperbuild.svg?style=shield
     :target: https://circleci.com/gh/CastXML/CastXMLSuperbuild
 
 This builds CastXML_ and its dependencies (LLVM/Clang) with CMake's


### PR DESCRIPTION
This should not be required for GCC 7 support because we still build against Clang 3.8 as opposed to 3.9.