### PR TITLE
Draft: A quick version of master for pygccxml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(extra_flags "-static-libstdc++")
 endif()
 # 2020-09-22 master
-set(CastXML_GIT_TAG v0.3.6 CACHE STRING "CastXML Git revision.")
+set(CastXML_GIT_TAG master CACHE STRING "CastXML Git revision.")
 ExternalProject_Add(castxml
   GIT_REPOSITORY https://github.com/CastXML/CastXML.git
   GIT_TAG ${CastXML_GIT_TAG}


### PR DESCRIPTION
Update to generate the binaries for  the master commit of the CastXML repository.

Needed because pygccxml testing downloads a version
of CastXML from data.kitware.com.