### PR TITLE
BUILD_SHARED_LIBS=OFF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       #####################################
       - name: Configure
         run: |
-          cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=Release
+          cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         shell: bash
 
       #####################################


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/ci.yml` file to modify the CMake configuration.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL67-R67): Updated the CMake configuration to disable the building of shared libraries by adding the `-DBUILD_SHARED_LIBS=OFF` flag.