### PR TITLE
[BUG] FIX ARTIFACTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,20 +89,21 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         shell: cmd
         run: |
-          cd build\castxml\bin
-          7z a ..\..\castxml-${{ matrix.os }}-${{ matrix.arch }}.zip castxml.exe
+          cd build
+          7z a castxml-${{ matrix.os }}-${{ matrix.arch }}.zip castxml
+          move castxml-${{ matrix.os }}-${{ matrix.arch }}.zip ..
 
       - name: Create Artifact (Non-Windows)
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         shell: bash
         run: |
-          cd build/castxml/bin
-          tar czvf ../../castxml-${{ matrix.os }}-${{ matrix.arch }}.tar.gz castxml
+          cd build
+          tar cvf castxml-${{ matrix.os }}-${{ matrix.arch }}.tar castxml
+          gzip -9 castxml-${{ matrix.os }}-${{ matrix.arch }}.tar
+          mv castxml-${{ matrix.os }}-${{ matrix.arch }}.tar.gz ..
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: castxml-${{ matrix.os }}-${{ matrix.arch }}
-          path: |
-            build/castxml-*.tar.gz
-            build/castxml-*.zip
+          path: ./castxml-${{ matrix.os }}-${{ matrix.arch }}.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       #####################################
       - name: Configure
         run: |
-          cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=Release
+          cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         shell: bash
 
       #####################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,15 @@ jobs:
       #####################################
       - name: Configure
         run: |
-          cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
+          cmake -B build -S . -GNinja
         shell: bash
 
       #####################################
       # Build the Superbuild
       #####################################
       - name: Build
-        run: cmake --build build --config Release
+        run: ninja -C build
+        shell: bash
 
       #####################################
       # [Optional] Run Tests


### PR DESCRIPTION
This pull request includes updates to the CI workflow configuration in the `.github/workflows/ci.yml` file. The most important changes involve modifying the build and artifact creation steps to streamline the process and ensure consistency across different operating systems.

Improvements to build configuration:

* Removed the `-DCMAKE_BUILD_TYPE=Release` flag from the `cmake` configuration command to simplify the build setup.
* Replaced the `cmake --build` command with `ninja -C build` for building the project, which aligns with the use of Ninja as the build system.

Enhancements to artifact creation:

* Updated the Windows artifact creation step to simplify the directory structure and file naming, ensuring the `castxml` binary is correctly archived.
* Modified the Non-Windows artifact creation step to streamline the tarball creation process and ensure the `castxml` binary is correctly archived and compressed.
* Adjusted the artifact upload path to match the new artifact naming convention, ensuring the correct files are uploaded.