### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04, ubuntu-22.04, macos-15 ]
+        os: [ ubuntu-24.04, ubuntu-22.04]
         arch: [ x86_64 ]
         include:
           - os: ubuntu-24.04-arm
             arch: aarch64
           - os: ubuntu-22.04-arm
             arch: aarch64
+          - os: macos-13
+            arch: x86_64
           - os: macos-15
             arch: arm64
           - os: windows-2025


### PR DESCRIPTION
This pull request includes changes to the CI configuration in the `.github/workflows/ci.yml` file to update the operating systems and architectures used in the testing matrix.

Updates to CI configuration:

* Removed `macos-15` from the `os` matrix and added `macos-13` with `x86_64` architecture.

macos-14 and macos-15 are only arm64 runners